### PR TITLE
A few changes

### DIFF
--- a/src/main/java/com/salted_broccoli/cuillere/Controller/UserController.java
+++ b/src/main/java/com/salted_broccoli/cuillere/Controller/UserController.java
@@ -1,4 +1,4 @@
-package com.salted_broccoli.cuillere.Controler;
+package com.salted_broccoli.cuillere.Controller;
 
 import com.salted_broccoli.cuillere.Model.User;
 import com.salted_broccoli.cuillere.Service.UserService;

--- a/src/main/java/com/salted_broccoli/cuillere/Model/User.java
+++ b/src/main/java/com/salted_broccoli/cuillere/Model/User.java
@@ -12,7 +12,7 @@ public class User {
 
     @GeneratedValue( strategy = GenerationType.SEQUENCE, generator = "USER_SEQ")
     @SequenceGenerator(name = "USER_SEQ", sequenceName = "USER_SEQ")
-    private Integer id;
+    private Long id;
     private String firstName;
     private String lastName;
     @Column(unique = true)

--- a/src/main/java/com/salted_broccoli/cuillere/Repository/UserRepository.java
+++ b/src/main/java/com/salted_broccoli/cuillere/Repository/UserRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository <User, Long> {
-    @Query(value="SELECT u FROM User u WHERE u.email=:email ")
-    Optional<User> findUserByEmail(String email);
+
+    User findUserByEmail(String email);
 
 }

--- a/src/main/java/com/salted_broccoli/cuillere/Service/AuthenticationService.java
+++ b/src/main/java/com/salted_broccoli/cuillere/Service/AuthenticationService.java
@@ -19,17 +19,16 @@ public class AuthenticationService implements UserDetailsService {
 
 
     @Override
-    public UserDetails loadUserByUsername(String s) throws UsernameNotFoundException {
-        Optional<User> user = userRepository
-                .findUserByEmail(s);
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findUserByEmail(username);
 
-        if (user.isPresent()) {
+        if(user == null) throw new UsernameNotFoundException(username);
 
-
-            return new org.springframework.security.core.userdetails.User(user.get().getEmail(), user.get().getPassword(), new ArrayList<>());
-        }
-
-        throw new UsernameNotFoundException(s);
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                new ArrayList<>()
+        );
     }
 
 }

--- a/src/main/java/com/salted_broccoli/cuillere/Service/UserService.java
+++ b/src/main/java/com/salted_broccoli/cuillere/Service/UserService.java
@@ -16,7 +16,7 @@ public class UserService {
     @Autowired
     UserRepository userRepository;
 
-    public User registration(final RegistrationForm form){
+    public User registration(RegistrationForm form){
         User user = new User();
         user.setFirstName(form.getFirstName());
         user.setLastName(form.getLastName());
@@ -26,8 +26,10 @@ public class UserService {
         }
 
     public User findUser(){
-        org.springframework.security.core.userdetails.User springUser = (org.springframework.security.core.userdetails.User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        //Spring Security-side identifier; tied to the user's session => user's email
+        String connectedUserEmail = SecurityContextHolder.getContext().getAuthentication().getName();
 
-        return userRepository.findUserByEmail(springUser.getUsername()).get();
+        //Fetch according to the email
+        return userRepository.findUserByEmail(connectedUserEmail);
     }
 }

--- a/src/main/java/com/salted_broccoli/cuillere/config/AppConfig.java
+++ b/src/main/java/com/salted_broccoli/cuillere/config/AppConfig.java
@@ -24,7 +24,7 @@ public class AppConfig extends WebSecurityConfigurerAdapter {
         http
                 .csrf().disable()
                 .authorizeRequests()
-                .antMatchers( "/static/**", "/register", "/login", "/resources/**")
+                .antMatchers( "/static/**", "/register", "/login", "/resources/**", "/registration")
                 .permitAll()
                 .anyRequest()
                 .authenticated()

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -21,7 +21,7 @@
 
                                 <p class="text-center h1 fw-bold mb-5 mx-1 mx-md-4 mt-4">Sign up</p>
 
-                                <form action="registration" th:action="@{/registration}" th:object="${registrationForm}" method="post" class="mx-1 mx-md-4">
+                                <form action="#" th:action="@{/registration}" th:object="${registrationForm}" method="post" class="mx-1 mx-md-4">
 
                                     <div class="d-flex flex-row align-items-center mb-4">
                                         <i class="fas fa-user fa-lg me-3 fa-fw"></i>


### PR DESCRIPTION
- Removal of redundant @Query in UserRepository, meaning JpaRepository automatically queries based on Email as the function is called findUserByEmail. Consequently, the Optional<> tag is no longer necessary.

- With no need for Optional<User> handling in AuthenticationService, the code becomes a lot more concise.

- UserService.findUser used an unnecessary typecasting, with removal of that and the Optional<User> from our query, it is a lot more concise while being functionally identical.

- Renamed Controler -> Controller.

- Added "/registration" to the authorized antMatchers in AppConfig.

- Removed action="registration" in register.html to avoid ambiguity.

- Changed User's id to Long, for 